### PR TITLE
Enhance Grid Selection with Color & Motif Capture + Motif Saving Functionality

### DIFF
--- a/modularmotifs/ui/grid_selection.py
+++ b/modularmotifs/ui/grid_selection.py
@@ -186,6 +186,24 @@ class GridSelection:
                         cell.config(bg=cell._orig_bg)
                         del cell._orig_bg
         print("Selected grids:", sorted(list(self.selected_coords)))
+
+        #--- New Functionality: Capture color and motif information ---
+        #Access the design instance from the KnitWindow.
+        design = self.knit_window._KnitWindow__design
+        selected_details = []
+        for (col, row) in sorted(list(self.selected_coords)):
+            # Get the effective RGB color at this grid cell.
+            cell_rgb = design.get_rgb(col, row)
+            # Get the motif (if any) associated with this grid cell.
+            cell_motif = design.get_motif(col, row)
+            selected_details.append({
+                "coords": (col, row),
+                "color": cell_rgb.hex(),
+                "motif": repr(cell_motif) if cell_motif is not None else None
+            })
+        print("Selected grid details:", selected_details)
+        #--- End New Functionality ---
+
         self.start_cell = None
         return "break"
 
@@ -216,6 +234,9 @@ class GridSelection:
                         cell.config(bg=cell._orig_bg)
                         del cell._orig_bg
 
+    def get_selected_coords(self):
+        return self.selected_coords
+
 #If desired, you can add a simple test routine here.
 if __name__ == "__main__":
     # For testing outside of the main interface, you might create a dummy window
@@ -241,8 +262,8 @@ if __name__ == "__main__":
         pass
 
     dummy = DummyKnitWindow()
-    dummy._KnitWindow__root = root
-    dummy._KnitWindow__cells = cells
+    dummy._root = root
+    dummy._cells = cells
 
     # Activate grid selection.
     gs = GridSelection(dummy)

--- a/modularmotifs/ui/motif_saver.py
+++ b/modularmotifs/ui/motif_saver.py
@@ -1,0 +1,64 @@
+import os
+import datetime
+
+def save_as_motif(knit_window):
+    """
+    Converts the currently selected grids into a motif and stores it in a Python file.
+    The motifs are saved in a file named 'saved_motifs.py' as a dictionary variable
+    'saved_motifs', where each key is a generated motif name and each value is a 2D list
+    of integers representing the color coding (1 for foreground, 2 for background, 3 for invisible).
+    """
+    # Retrieve the selected grid coordinates from the GridSelection instance.
+    coords = knit_window._KnitWindow__grid_selector.get_selected_coords()
+    if not coords:
+        print("No grids selected to save as motif!")
+        return
+
+    design = knit_window._KnitWindow__design
+    # Compute the bounding box of the selection.
+    cols = [col for (col, row) in coords]
+    rows = [row for (col, row) in coords]
+    min_col, max_col = min(cols), max(cols)
+    min_row, max_row = min(rows), max(rows)
+    width = max_col - min_col + 1
+    height = max_row - min_row + 1
+
+    # Build a 2D list representing the motif.
+    # Initialize all cells with the invisible value (3).
+    motif_data = [[3 for _ in range(width)] for _ in range(height)]
+    for (col, row) in coords:
+        rel_col = col - min_col
+        rel_row = row - min_row
+        # Retrieve the color code at (col, row); its .value is assumed to be 1 (fore), 2 (back), or 3 (invis).
+        motif_data[rel_row][rel_col] = design.get_color(col, row).value
+
+    # Generate a motif name using the current timestamp.
+    motif_name = "motif_" + datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    # File where motifs are saved.
+    saved_file = "modularmotifs/motiflibrary/saved_motifs.py"
+
+    # Load existing motifs from the file if it exists.
+    if os.path.exists(saved_file):
+        context = {}
+        with open(saved_file, "r") as f:
+            file_content = f.read()
+        try:
+            exec(file_content, context)
+            saved = context.get("saved_motifs", {})
+        except Exception as e:
+            print("Error reading saved motifs file. Starting fresh.", e)
+            saved = {}
+    else:
+        saved = {}
+
+    # Add the new motif to the dictionary.
+    saved[motif_name] = motif_data
+
+    # Write the updated motifs dictionary back to the file.
+    with open(saved_file, "w") as f:
+        f.write("# This file is auto-generated. Do not edit manually.\n")
+        f.write("saved_motifs = ")
+        f.write(repr(saved))
+        f.write("\n")
+    print(f"Saved motif '{motif_name}' to {saved_file}")


### PR DESCRIPTION
- Captures RGB color values and motif details for selected grid cells.
- Added "Save as Motif" button to trigger motif saving which calls save_as_motif(self) when clicked.
- Created motif_saver.py to handle motif extraction and saving.
- Converts the currently selected grids into a motif and stores it in a Python file. Saves motifs in saved_motifs.py
- Ensures existing motifs are preserved when saving new ones.
- In interface.py, imported a new function save_as_motif from motif_saver.py.

